### PR TITLE
rename library

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/influxdb1-client/v2"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"


### PR DESCRIPTION
the [InfluxDB v1 client](https://github.com/influxdata/influxdb1-client) was renamed, this updates the import to the new name.

this fixes https://github.com/reap/MQTT-InfluxDB-bridge/issues/11